### PR TITLE
让安装更傻瓜

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ pip install transformers
 pip install SentencePiece
 # api demo 依赖
 pip install fastapi uvicorn
+# gradio demo 依赖
+pip install mdtex2html gradio
 ```
 
 ### 使用示例

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ conda activate educhat
 pip install transformers
 # 项目中用到LlamaTokenizer的需要安装这个
 pip install SentencePiece
+# api demo 依赖
+pip install fastapi uvicorn
 ```
 
 ### 使用示例


### PR DESCRIPTION
1. 添加pytorch官方路径
2. 安装中提示缺乏SentencePiece
```
ImportError: 
LlamaTokenizer requires the SentencePiece library but it was not found in your environment. Checkout the instructions on the
installation page of its repo: https://github.com/google/sentencepiece#installation and follow the ones
that match your environment. Please note that you may need to restart your runtime after installation.
```
3. API demo依赖fastapi和uvicorn
4. gradio demo依赖